### PR TITLE
Remove go report badge because it's site keeps breaking and reporting the wrong grade for this project

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 # _murex_
 
-[![Go Report Card](https://goreportcard.com/badge/github.com/lmorg/murex)](https://goreportcard.com/report/github.com/lmorg/murex)
 [![GoDoc](https://godoc.org/github.com/lmorg/murex?status.svg)](https://godoc.org/github.com/lmorg/murex)
 [![CodeBuild](https://codebuild.eu-west-1.amazonaws.com/badges?uuid=eyJlbmNyeXB0ZWREYXRhIjoib3cxVnoyZUtBZU5wN1VUYUtKQTJUVmtmMHBJcUJXSUFWMXEyc2d3WWJldUdPTHh4QWQ1eFNRendpOUJHVnZ5UXBpMXpFVkVSb3k2UUhKL2xCY2JhVnhJPSIsIml2UGFyYW1ldGVyU3BlYyI6Im9QZ2dPS3ozdWFyWHIvbm8iLCJtYXRlcmlhbFNldFNlcmlhbCI6MX0%3D&branch=master)](DOWNLOAD.md)
 [![CircleCI](https://circleci.com/gh/lmorg/murex/tree/master.svg?style=svg)](https://circleci.com/gh/lmorg/murex/tree/master)

--- a/lang/variables.go
+++ b/lang/variables.go
@@ -232,7 +232,6 @@ func (v *Variables) Unset(name string) error {
 		return errVarNotExist
 	}
 
-	variable = nil
 	delete(v.vars, name)
 	v.mutex.Unlock()
 	return nil


### PR DESCRIPTION
There's also a long standing issue where there are 3 misspell errors on terms that are spelt correctly.