### PR TITLE
Scheduler flags

### DIFF
--- a/builtins/core/processes/fid-list.go
+++ b/builtins/core/processes/fid-list.go
@@ -109,7 +109,7 @@ func cmdFidListTTY(p *lang.Process) error {
 			process.Parent.Id,
 			process.Scope.Id,
 			process.State.String(),
-			process.RunMode,
+			process.RunMode.String(),
 			yn(process.IsBackground),
 			process.NamedPipeOut,
 			process.NamedPipeErr,
@@ -136,7 +136,7 @@ func cmdFidListCSV(p *lang.Process) error {
 			process.Parent.Id,
 			process.Scope.Id,
 			process.State.String(),
-			process.RunMode,
+			process.RunMode.String(),
 			yn(process.IsBackground),
 			process.NamedPipeOut,
 			process.NamedPipeErr,
@@ -150,19 +150,6 @@ func cmdFidListCSV(p *lang.Process) error {
 	}
 	return nil
 }
-
-/*type fidList struct {
-	FID        uint32
-	Parent     uint32
-	Scope      uint32
-	State      string
-	RunMode    string `json:"Run Mode"`
-	BG         bool   `json:"Background"`
-	OutPipe    string `json:"Out Pipe"`
-	ErrPipe    string `json:"Err Pipe"`
-	Command    string
-	Parameters string
-}*/
 
 func cmdFidListPipe(p *lang.Process) error {
 	p.Stdout.SetDataType(types.JsonLines)

--- a/flags.go
+++ b/flags.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/lmorg/murex/config"
 	"github.com/lmorg/murex/debug"
+	"github.com/lmorg/murex/lang"
 	"github.com/lmorg/murex/lang/types"
 )
 
@@ -34,6 +35,9 @@ func readFlags() {
 	flag.BoolVar(&fRunTests, "run-tests", false, "Run all tests and exit")
 	flag.BoolVar(&fEcho, "echo", false, "Echo on")
 	flag.BoolVar(&fSh, "murex", false, "")
+
+	flag.BoolVar(&lang.FlagTry, "try", false, "Enable a global `try` block")
+	flag.BoolVar(&lang.FlagTryPipe, "trypipe", false, "Enable a global `trypipe` block")
 
 	flag.Parse()
 

--- a/flags_test.mx
+++ b/flags_test.mx
@@ -1,0 +1,53 @@
+# This file tests flags but running the murex executable
+
+function try-semicolon {
+    ./murex --try -c (err: "foo"; out "bar") 
+}
+
+test: unit function try-semicolon {
+    "StderrRegex": "foo",
+    "ExitNum":     1
+}
+
+function try-pipe {
+    ./murex --try -c (err: "foo" -> out "bar") 
+}
+
+test: unit function try-pipe {
+    "StderrRegex": "foo",
+    "StdoutRegex": "bar"
+}
+
+function try-errpipe {
+    ./murex --try -c (err: "foo" ? out "bar") 
+}
+
+test: unit function try-errpipe {
+    "StdoutRegex": "bar"
+}
+
+function trypipe-semicolon {
+    ./murex --trypipe -c (err: "foo"; out "bar") 
+}
+
+test: unit function trypipe-semicolon {
+    "StderrRegex": "foo",
+    "ExitNum":     1
+}
+
+function trypipe-pipe {
+    ./murex --trypipe -c (err: "foo" -> out "bar") 
+}
+
+test: unit function trypipe-pipe {
+    "StderrRegex": "foo",
+    "ExitNum":     1
+}
+
+function trypipe-errpipe {
+    ./murex --trypipe -c (err: "foo" ? out "bar") 
+}
+
+test: unit function trypipe-errpipe {
+    "ExitNum":     1
+}

--- a/flags_test.mx
+++ b/flags_test.mx
@@ -1,7 +1,7 @@
 # This file tests flags but running the murex executable
 
 function try-semicolon {
-    ./murex --try -c (err: "foo"; out "bar") 
+    exec: $MUREX_EXE --try -c (err: "foo"; out "bar") 
 }
 
 test: unit function try-semicolon {
@@ -10,7 +10,7 @@ test: unit function try-semicolon {
 }
 
 function try-pipe {
-    ./murex --try -c (err: "foo" -> out "bar") 
+    exec: $MUREX_EXE --try -c (err: "foo" -> out "bar") 
 }
 
 test: unit function try-pipe {
@@ -19,7 +19,7 @@ test: unit function try-pipe {
 }
 
 function try-errpipe {
-    ./murex --try -c (err: "foo" ? out "bar") 
+    exec: $MUREX_EXE --try -c (err: "foo" ? out "bar") 
 }
 
 test: unit function try-errpipe {
@@ -27,7 +27,7 @@ test: unit function try-errpipe {
 }
 
 function trypipe-semicolon {
-    ./murex --trypipe -c (err: "foo"; out "bar") 
+    exec: $MUREX_EXE --trypipe -c (err: "foo"; out "bar") 
 }
 
 test: unit function trypipe-semicolon {
@@ -36,7 +36,7 @@ test: unit function trypipe-semicolon {
 }
 
 function trypipe-pipe {
-    ./murex --trypipe -c (err: "foo" -> out "bar") 
+    exec: $MUREX_EXE --trypipe -c (err: "foo" -> out "bar") 
 }
 
 test: unit function trypipe-pipe {
@@ -45,7 +45,7 @@ test: unit function trypipe-pipe {
 }
 
 function trypipe-errpipe {
-    ./murex --trypipe -c (err: "foo" ? out "bar") 
+    exec: $MUREX_EXE --trypipe -c (err: "foo" ? out "bar") 
 }
 
 test: unit function trypipe-errpipe {

--- a/lang/fork.go
+++ b/lang/fork.go
@@ -281,7 +281,7 @@ func (fork *Fork) Execute(block []rune) (exitNum int, err error) {
 
 	// Support for different run modes:
 	switch fork.RunMode {
-	case runmode.Normal, runmode.Shell:
+	case runmode.Normal:
 		exitNum = runModeNormal(procs)
 
 	case runmode.Try:

--- a/lang/init.go
+++ b/lang/init.go
@@ -29,10 +29,10 @@ func InitEnv() {
 	ShellProcess.Parent = ShellProcess
 	ShellProcess.Previous = ShellProcess
 	ShellProcess.Next = ShellProcess
-	ShellProcess.Config = config.InitConf //InitConf.Copy(ShellProcess.Id)
+	ShellProcess.Config = config.InitConf
 	ShellProcess.Tests = NewTests(ShellProcess)
 	ShellProcess.Variables = NewVariables(ShellProcess)
-	//ShellProcess.RunMode = runmode.Normal
+	//ShellProcess.RunMode = runmode.Normal // defaults to Normal due to Normal == 0
 	ShellProcess.Stdout = new(term.Out)
 	ShellProcess.Stderr = term.NewErr(true) // TODO: check this is overridden by `config set ...`
 	ShellProcess.Kill = func() {}

--- a/lang/init.go
+++ b/lang/init.go
@@ -15,6 +15,11 @@ import (
 	"github.com/lmorg/murex/utils/json"
 )
 
+var (
+	FlagTry     bool
+	FlagTryPipe bool
+)
+
 // InitEnv initialises murex. Exported function to enable unit tests.
 func InitEnv() {
 	ShellProcess.State.Set(state.Executing)
@@ -27,11 +32,19 @@ func InitEnv() {
 	ShellProcess.Config = config.InitConf //InitConf.Copy(ShellProcess.Id)
 	ShellProcess.Tests = NewTests(ShellProcess)
 	ShellProcess.Variables = NewVariables(ShellProcess)
-	ShellProcess.RunMode = runmode.Shell
+	//ShellProcess.RunMode = runmode.Normal
 	ShellProcess.Stdout = new(term.Out)
 	ShellProcess.Stderr = term.NewErr(true) // TODO: check this is overridden by `config set ...`
 	ShellProcess.Kill = func() {}
 	ShellProcess.FileRef = &ref.File{Source: &ref.Source{Module: config.AppName}}
+
+	if FlagTry {
+		ShellProcess.RunMode = runmode.Try
+	}
+
+	if FlagTryPipe {
+		ShellProcess.RunMode = runmode.TryPipe
+	}
 
 	// Sets $SHELL to be murex
 	shellEnv, err := os.Executable()

--- a/lang/proc/runmode/runmode.go
+++ b/lang/proc/runmode/runmode.go
@@ -8,7 +8,6 @@ type RunMode int
 // These are the different supported run modes
 const (
 	Normal RunMode = iota
-	Shell
 	Try
 	TryPipe
 	Evil

--- a/lang/proc/runmode/runmode_string.go
+++ b/lang/proc/runmode/runmode_string.go
@@ -9,15 +9,14 @@ func _() {
 	// Re-run the stringer command to generate them again.
 	var x [1]struct{}
 	_ = x[Normal-0]
-	_ = x[Shell-1]
-	_ = x[Try-2]
-	_ = x[TryPipe-3]
-	_ = x[Evil-4]
+	_ = x[Try-1]
+	_ = x[TryPipe-2]
+	_ = x[Evil-3]
 }
 
-const _RunMode_name = "NormalShellTryTryPipeEvil"
+const _RunMode_name = "NormalTryTryPipeEvil"
 
-var _RunMode_index = [...]uint8{0, 6, 11, 14, 21, 25}
+var _RunMode_index = [...]uint8{0, 6, 9, 16, 20}
 
 func (i RunMode) String() string {
 	if i < 0 || i >= RunMode(len(_RunMode_index)-1) {

--- a/lang/proc/runmode/runmode_test.go
+++ b/lang/proc/runmode/runmode_test.go
@@ -18,7 +18,6 @@ func TestRunmodeStringer(t *testing.T) {
 	}()
 
 	t.Log(Normal.String())
-	t.Log(Shell.String())
 	t.Log(Try.String())
 	t.Log(TryPipe.String())
 	t.Log(Evil.String())

--- a/lang/test_units.go
+++ b/lang/test_units.go
@@ -354,7 +354,7 @@ func runTest(results *TestResults, fileRef *ref.File, plan *UnitTestPlan, functi
 
 		case !rx.Match(stderr):
 			passed = false
-			addReport(TestFailed, tMsgRegexMismatch("StderrRegex", stdout))
+			addReport(TestFailed, tMsgRegexMismatch("StderrRegex", stderr))
 
 		default:
 			addReport(TestInfo, tMsgRegexMatch("StderrRegex"))

--- a/lang/variables_reserved.go
+++ b/lang/variables_reserved.go
@@ -1,5 +1,7 @@
 package lang
 
+import "os"
+
 type self struct {
 	Parent     uint32
 	Scope      uint32
@@ -24,4 +26,13 @@ func getVarSelf(p *Process) interface{} {
 
 func getVarParams(p *Process) interface{} {
 	return append([]string{p.Scope.Name}, p.Scope.Parameters.Params...)
+}
+
+func getVarMurexExe() interface{} {
+	path, err := os.Executable()
+	if err != nil {
+		return err.Error()
+	}
+
+	return path
 }

--- a/lang/variables_test.go
+++ b/lang/variables_test.go
@@ -15,24 +15,7 @@ func TestVariablesDefaults(t *testing.T) {
 	testVariables(t, F_DEFAULTS, "F_DEFAULTS")
 }
 
-/*// TestVariablesDefault tests with the F_FUNCTION fork flag set
-func TestVariablesFunction(t *testing.T) {
-	i := atomic.AddInt32(&runOnce, 1)
-	if i > 0 {
-		return
-	}
-
-	ShellProcess.Variables = newVariables(ShellProcess, masterVarTable)
-	testVariables(t, F_FUNCTION, "F_FUNCTION")
-}
-
-// TestVariablesDefault tests with the F_NEW_VARTABLE fork flag set
-func TestVariablesNewVartable(t *testing.T) {
-	testVariables(t, F_NEW_VARTABLE, "F_NEW_VARTABLE")
-}*/
-
-// testVariables is the main testing function for variables under different
-// fork scenarios
+// testVariables is the main testing function for variables
 func testVariables(t *testing.T, flags int, details string) {
 	t.Log("Testing with flags: " + details)
 	const (
@@ -50,27 +33,6 @@ func testVariables(t *testing.T, flags int, details string) {
 
 	count.Tests(t, 4)
 	p := NewTestProcess()
-	/*orig := p.Variables
-
-	err := orig.Set(p, "number", origNum, types.Number)
-	if err != nil {
-		t.Error("Unable to set number in original. " + err.Error())
-	}
-
-	err = orig.Set(p, "integer", origInt, types.Integer)
-	if err != nil {
-		t.Error("Unable to set integer in original. " + err.Error())
-	}
-
-	err = orig.Set(p, "string", origStr, types.String)
-	if err != nil {
-		t.Error("Unable to set string in original. " + err.Error())
-	}
-
-	err = orig.Set(p, "boolean", origBool, types.Boolean)
-	if err != nil {
-		t.Error("Unable to set boolean in original. " + err.Error())
-	}*/
 
 	// Create a referenced variable table
 	count.Tests(t, 4)
@@ -96,44 +58,6 @@ func testVariables(t *testing.T, flags int, details string) {
 	if err != nil {
 		t.Error("Unable to set boolean in copy. " + err.Error())
 	}
-
-	/*// test values changed
-	count.Tests(t, 4)
-
-	if copy.varTable.vars[0].Value != orig.varTable.vars[0].Value {
-		t.Error("Copy and original shouldn't share same value for number.")
-	}
-
-	if copy.varTable.vars[1].Value != orig.varTable.vars[1].Value {
-		t.Error("Copy and original shouldn't share same value for integer.")
-	}
-
-	if copy.varTable.vars[2].Value != orig.varTable.vars[2].Value {
-		t.Error("Copy and original shouldn't share same value for string.")
-	}
-
-	if copy.varTable.vars[3].Value != orig.varTable.vars[3].Value {
-		t.Error("Copy and original shouldn't share same value for boolean.")
-	}
-
-	// test copy values
-	count.Tests(t, 4)
-
-	if (copy.varTable.vars[0].Value.(float64) != copyNum) == (flags != F_FUNCTION) {
-		t.Error("Copy number not same as expected value.")
-	}
-
-	if (copy.varTable.vars[1].Value.(int) != copyInt) == (flags != F_FUNCTION) {
-		t.Error("Copy integer not same as expected value.")
-	}
-
-	if (copy.varTable.vars[2].Value.(string) != copyStr) == (flags != F_FUNCTION) {
-		t.Error("Copy string not same as expected value.")
-	}
-
-	if (copy.varTable.vars[3].Value.(bool) != copyBool) == (flags != F_FUNCTION) {
-		t.Error("Copy boolean not same as expected value.")
-	}*/
 
 	// test GetValue
 	count.Tests(t, 4)
@@ -172,24 +96,6 @@ func testVariables(t *testing.T, flags int, details string) {
 	if types.IsTrue([]byte(copy.GetString("boolean")), 0) != copyBool {
 		t.Error("Copy var table not returning correct boolean converted value using GetString.")
 	}
-
-	/*count.Tests(t, 4)
-	err = copy.Set("new", "string", types.String)
-	if err != nil {
-		t.Error("Unable to create new string. " + err.Error())
-	}
-
-	if orig.GetString("new") != "" {
-		t.Error("New string exists on original when not expected.")
-	}
-
-	if orig.GetString("new") == "string" {
-		t.Error("New string saved on copy was replicated on original - this shouldn't happen.")
-	}
-
-	if copy.GetString("new") != "string" {
-		t.Error("New string on copy not retriving correctly: '" + copy.GetString("new") + "'")
-	}*/
 }
 
 // TestReservedVariables tests the Vars structure

--- a/shell/hint.go
+++ b/shell/hint.go
@@ -172,13 +172,6 @@ func hintCodeBlock() []rune {
 		return []rune{}
 	}
 
-	//stdout := streams.NewStdin()
-	//branch := lang.ShellProcess.BranchFID()
-	//branch.IsBackground = true
-	//defer branch.Close()
-	//exitNum, err := lang.RunBlockExistingConfigSpace([]rune(ht.(string)), nil, stdout, nil, branch.Process)
-	//fork := lang.ShellProcess.Fork(lang.F_NEW_SCOPE | lang.F_NEW_CONFIG | lang.F_NEW_TESTS | lang.F_BACKGROUND | lang.F_BACKGROUND | lang.F_NO_STDIN | lang.F_CREATE_STDOUT | lang.F_NO_STDERR)
-
 	fork := lang.ShellProcess.Fork(lang.F_FUNCTION | lang.F_BACKGROUND | lang.F_NO_STDIN | lang.F_CREATE_STDOUT | lang.F_NO_STDERR)
 	fork.Name = "shell (hint-text-func)"
 	exitNum, err := fork.Execute([]rune(ht.(string)))

--- a/source.go
+++ b/source.go
@@ -53,6 +53,7 @@ func execSource(source []rune, sourceRef *ref.Source) {
 	if sourceRef != nil {
 		fork.FileRef.Source = sourceRef
 	}
+	fork.RunMode = lang.ShellProcess.RunMode
 	exitNum, err := fork.Execute(source)
 
 	if err != nil {

--- a/test/ci-murex.sh
+++ b/test/ci-murex.sh
@@ -34,4 +34,7 @@ echo "$(cat ./murex-test-count.txt) tests completed"
 echo "Run murex shell script unit tests...."
 murex --run-tests
 
+echo "Run murex flag unit tests...."
+./murex: -c 'source: ./flags_test.mx; try {test: run *}'
+
 echo "Fin!"

--- a/test/ci-murex.sh
+++ b/test/ci-murex.sh
@@ -35,6 +35,6 @@ echo "Run murex shell script unit tests...."
 murex --run-tests
 
 echo "Run murex flag unit tests...."
-./murex -c 'source: ./flags_test.mx; try {test: run *}'
+murex -c 'source: ./flags_test.mx; try {test: run *}'
 
 echo "Fin!"

--- a/test/ci-murex.sh
+++ b/test/ci-murex.sh
@@ -35,6 +35,6 @@ echo "Run murex shell script unit tests...."
 murex --run-tests
 
 echo "Run murex flag unit tests...."
-./murex: -c 'source: ./flags_test.mx; try {test: run *}'
+./murex -c 'source: ./flags_test.mx; try {test: run *}'
 
 echo "Fin!"

--- a/test/pre-push
+++ b/test/pre-push
@@ -22,6 +22,9 @@ echo "Running unit tests on builtin profiles...."
 go build github.com/lmorg/murex || exit 1
 ./murex --run-tests || exit 1
 
+echo "Run murex flag unit tests...."
+./murex -c 'source: ./flags_test.mx; try {test: run *}' || exit 1
+
 echo "Checking subset of alternative OS builds...."
 test/test_goos.mx || exit 1
 


### PR DESCRIPTION
Add support for `--try` and `--trypipe` flags.

Also sneaked support in for $MUREX_EXE to support running shebang tests