### PR TITLE
Version 2: final

### DIFF
--- a/docs/blog/v2.0.md
+++ b/docs/blog/v2.0.md
@@ -1,19 +1,35 @@
-# _murex_ Shell Docs
+# _murex_ Blogs
 
-## Blog: What's new in murex v2.0
+## What's new in murex v2.0
 
 > The feature comes with spellchecking, inlined images, smarter syntax completion and more
-> Published: 2021-04-17 12:49:00 +0000 UTC
 
 This release seems some major upgrade to the default experience:
 
-* inlined spellchecking enabled by default (requires `aspell` installed)
-* support for inlining images enabled by default (was previously an external
+* Inlined spellchecking enabled by default (requires `aspell` installed)
+  [![asciicast](https://asciinema.org/a/408024.svg)](https://asciinema.org/a/408024)
+  (see spellcheck link below)
+
+* Support for inlining images enabled by default (was previously an external
   module: https://github.com/lmorg/murex-module-open-image)
-* massively overhauled syntax completion
-* rewritten config backend which copies less data around
-* significantly more features documented (see https://murex.rocks)
-* plus this new blog!
+  [![asciicast](https://asciinema.org/a/408028.svg)](https://asciinema.org/a/408028)
+
+* Massively overhauled syntax completion
+  [![asciicast](https://asciinema.org/a/408029.svg)](https://asciinema.org/a/408029)
+
+* Additional tab autocompletions included in base install
+
+* Minor `readline` bug fixes (https://github.com/lmorg/murex/pull/312/commits/5064cf418f768d2ba4a6bbc7c74e46629ef3b5f3)
+
+* Rewritten config backend which copies less data around
+
+* Significantly more features documented (see https://murex.rocks)
+
+* Plus this new blog!
+
+<hr>
+
+Published: 17.04.2021 at 12:49
 
 ## See Also
 

--- a/docs/user-guide/spellcheck.md
+++ b/docs/user-guide/spellcheck.md
@@ -6,7 +6,7 @@
 
 _murex_ supports inline spellchecking, where errors are underlined. For example
 
-> » out: "The quick brown fox jumped over the lazy __madeupword__"
+[![asciicast](https://asciinema.org/a/408024.svg)](https://asciinema.org/a/408024)
 
 However to use there there needs to be a few satisfied prerequisites, not all
 of which will be enabled by default:

--- a/gen/blog-md-doc.tmpl
+++ b/gen/blog-md-doc.tmpl
@@ -1,11 +1,14 @@
-# _murex_ Shell Docs
+# _murex_ Blogs
 
-## {{ md .CategoryTitle }}: {{ md .Title }}
+## {{ md .Title }}
 {{ if .Summary }}
 > {{ md .Summary }}{{ end }}
-> Published: {{ .DateTime }}
 
 {{ md (include .Description) }}{{ if .Related }}
+
+<hr>
+
+Published: {{ date .DateTime }} at {{ time .DateTime }}
 
 ## See Also
 

--- a/gen/blog/v2.0_doc.yaml
+++ b/gen/blog/v2.0_doc.yaml
@@ -8,13 +8,26 @@
   Description: |-
     This release seems some major upgrade to the default experience:
 
-    * inlined spellchecking enabled by default (requires `aspell` installed)
-    * support for inlining images enabled by default (was previously an external
+    * Inlined spellchecking enabled by default (requires `aspell` installed)
+      [![asciicast](https://asciinema.org/a/408024.svg)](https://asciinema.org/a/408024)
+      (see spellcheck link below)
+
+    * Support for inlining images enabled by default (was previously an external
       module: https://github.com/lmorg/murex-module-open-image)
-    * massively overhauled syntax completion
-    * rewritten config backend which copies less data around
-    * significantly more features documented (see https://murex.rocks)
-    * plus this new blog!
+      [![asciicast](https://asciinema.org/a/408028.svg)](https://asciinema.org/a/408028)
+
+    * Massively overhauled syntax completion
+      [![asciicast](https://asciinema.org/a/408029.svg)](https://asciinema.org/a/408029)
+
+    * Additional tab autocompletions included in base install
+
+    * Minor `readline` bug fixes (https://github.com/lmorg/murex/pull/312/commits/5064cf418f768d2ba4a6bbc7c74e46629ef3b5f3)
+
+    * Rewritten config backend which copies less data around
+
+    * Significantly more features documented (see https://murex.rocks)
+
+    * Plus this new blog!
   Synonyms:
   Related:
   - user-guide/spellcheck

--- a/gen/user-guide/spellcheck_doc.yaml
+++ b/gen/user-guide/spellcheck_doc.yaml
@@ -7,7 +7,7 @@
   Description: |-
     _murex_ supports inline spellchecking, where errors are underlined. For example
 
-    > » out: "The quick brown fox jumped over the lazy __madeupword__"
+    [![asciicast](https://asciinema.org/a/408024.svg)](https://asciinema.org/a/408024)
 
     However to use there there needs to be a few satisfied prerequisites, not all
     of which will be enabled by default:

--- a/shell/syntax.go
+++ b/shell/syntax.go
@@ -26,6 +26,10 @@ func syntaxCompletion(line []rune, change string, pos int) ([]rune, int) {
 		part, _ = parse(line[:pos+1])
 	}
 
+	if part.Escaped || part.Comment {
+		return line, pos
+	}
+
 	if len(line) > 1 && pos > 0 && line[pos-1] == '\\' {
 		return line, pos
 	}

--- a/shell/syntax_test.go
+++ b/shell/syntax_test.go
@@ -471,3 +471,67 @@ func TestSyntaxCompletionsQuotesInsideBrackets(t *testing.T) {
 
 	testSyntaxCompletions(t, tests)
 }
+
+func TestSyntaxCompletionsComment(t *testing.T) {
+	tests := []testSyntaxCompletionsType{
+		{
+			Line:     `# {_`,
+			Change:   `{`,
+			Expected: `# {_`,
+		},
+		{
+			Line:     `# (_`,
+			Change:   `(`,
+			Expected: `# (_`,
+		},
+		{
+			Line:     `# [_`,
+			Change:   `[`,
+			Expected: `# [_`,
+		},
+		{
+			Line:     `# '_`,
+			Change:   `'`,
+			Expected: `# '_`,
+		},
+		{
+			Line:     `# "_`,
+			Change:   `"`,
+			Expected: `# "_`,
+		},
+	}
+
+	testSyntaxCompletions(t, tests)
+}
+
+func TestSyntaxCompletionsEscaped(t *testing.T) {
+	tests := []testSyntaxCompletionsType{
+		{
+			Line:     `\{_`,
+			Change:   `{`,
+			Expected: `\{_`,
+		},
+		{
+			Line:     `\(_`,
+			Change:   `(`,
+			Expected: `\(_`,
+		},
+		{
+			Line:     `\[_`,
+			Change:   `[`,
+			Expected: `\[_`,
+		},
+		{
+			Line:     `\'_`,
+			Change:   `'`,
+			Expected: `\'_`,
+		},
+		{
+			Line:     `\"_`,
+			Change:   `"`,
+			Expected: `\"_`,
+		},
+	}
+
+	testSyntaxCompletions(t, tests)
+}

--- a/utils/parser/parser.go
+++ b/utils/parser/parser.go
@@ -29,6 +29,7 @@ type ParsedTokens struct {
 	Loc           int
 	VarLoc        int
 	Escaped       bool
+	Comment       bool
 	QuoteSingle   bool
 	QuoteDouble   bool
 	QuoteBrace    int
@@ -109,6 +110,7 @@ func Parse(block []rune, pos int) (pt ParsedTokens, syntaxHighlighted string) {
 				*pt.pop += `#`
 				syntaxHighlighted += string(block[i])
 			default:
+				pt.Comment = true
 				syntaxHighlighted += hlComment + string(block[i:]) + ansi.Reset
 				return
 			}


### PR DESCRIPTION
This release seems some major upgrade to the default experience:

* Inlined spellchecking enabled by default (requires `aspell` installed)
  [![asciicast](https://asciinema.org/a/408024.svg)](https://asciinema.org/a/408024)
  (https://murex.rocks/docs/user-guide/spellcheck.html)

* Support for inlining images enabled by default (was previously an external
  module: https://github.com/lmorg/murex-module-open-image)
  [![asciicast](https://asciinema.org/a/408028.svg)](https://asciinema.org/a/408028)

* Massively overhauled syntax completion
  [![asciicast](https://asciinema.org/a/408029.svg)](https://asciinema.org/a/408029)

* Additional tab autocompletions included in base install

* Minor `readline` bug fixes (https://github.com/lmorg/murex/pull/312/commits/5064cf418f768d2ba4a6bbc7c74e46629ef3b5f3)

* Rewritten config backend which copies less data around

* Significantly more features documented (see https://murex.rocks)

* Plus this new blog!