### PR TITLE
#362 fix two panics in readline API

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -5,7 +5,7 @@ const Name = "murex"
 
 // Version number of $SHELL
 // Format of version string should be "(major).(minor).(revision) DESCRIPTION"
-const Version = "2.2.1200 BETA"
+const Version = "2.2.1300 BETA"
 
 // Copyright is the copyright owner string
 const Copyright = "© 2018-2021 Laurence Morgan"

--- a/utils/readline/readline.go
+++ b/utils/readline/readline.go
@@ -144,7 +144,9 @@ func (rl *Instance) Readline() (_ string, err error) {
 
 		// Slow or invisible tab completions shouldn't lock up cursor movement
 		if rl.modeTabCompletion && len(rl.tcSuggestions) == 0 {
-			rl.delayedTabContext.cancel()
+			if rl.delayedTabContext.cancel != nil {
+				rl.delayedTabContext.cancel()
+			}
 			rl.modeTabCompletion = false
 			rl.updateHelpers()
 		}
@@ -204,12 +206,17 @@ func (rl *Instance) Readline() (_ string, err error) {
 				suggestions = rl.tcSuggestions
 			}
 
-			if rl.modeTabCompletion /*&& len(suggestions) > 0*/ {
+			if rl.modeTabCompletion || len(rl.tfLine) != 0 /*&& len(suggestions) > 0*/ {
+				tfLine := rl.tfLine
 				cell := (rl.tcMaxX * (rl.tcPosY - 1)) + rl.tcOffset + rl.tcPosX - 1
 				rl.clearHelpers()
 				rl.resetTabCompletion()
 				rl.renderHelpers()
-				rl.insert([]rune(suggestions[cell]))
+				if len(suggestions) > 0 {
+					rl.insert([]rune(suggestions[cell]))
+				} else {
+					rl.insert(tfLine)
+				}
 				continue
 			}
 			rl.carridgeReturn()


### PR DESCRIPTION
This should address #362 but upon investigating it I spotted another panic while using the regex search in readline (where there are no results and the user presses `\n`). That now pushes the regex search term into the active command line (user should press `ESC` to close the regex find).