### PR TITLE
add error-handling in get-type

### DIFF
--- a/builtins/core/typemgmt/gettype.go
+++ b/builtins/core/typemgmt/gettype.go
@@ -40,6 +40,9 @@ func cmdGetType(p *lang.Process) error {
 		dt = p.Variables.GetDataType(v[1:])
 
 	case v == "stdin":
+		if (p.Scope.Stdin == nil) {
+			return errors.New("stdin must be used within a function or code block. Run `murex-docs stdin` for more information.")
+		}
 		dt = p.Scope.Stdin.GetDataType()
 
 	default:


### PR DESCRIPTION
Invoking `get-type stdin` directly from the command prompt (i.e. not within a function) causes Murex to panic.

Added error-handling to avoid this and point the user to the docs for `stdin`.