### PR TITLE
docs: add exit number details to "if" docs

### DIFF
--- a/builtins/core/structs/if_doc.yaml
+++ b/builtins/core/structs/if_doc.yaml
@@ -86,6 +86,8 @@
     ```
   Flags:
   Detail: |-
+    ### Pipelines and Output
+
     The conditional block can contain entire pipelines - even multiple lines of code
     let alone a single pipeline - as well as solitary commands as demonstrated in
     the examples above. However the conditional block does not output STDOUT nor
@@ -96,6 +98,24 @@
     use either a Murex named pipe to redirect the output, or test or debug flags
     (depending on your use case) if you only need to occasionally inspect the
     conditionals output.
+
+    ### Exit Numbers
+
+    When evaluating a command or code block, `if` will treat an exit number less
+    than 0 as true, and one greater than 0 as false. When the exit number is 0, `if`
+    will examine the stdout of the command or code block. If there is no output, or
+    the output is one of the following strings, `if` will evaluate the command or
+    code block as false. Otherwise, it will be considered true.
+
+    * `0`
+    * `disabled`
+    * `fail`
+    * `failed`
+    * `false`
+    * `no`
+    * `null`
+    * `off`
+
   Synonyms:
     - if
     - "!if"

--- a/docs/commands/if.md
+++ b/docs/commands/if.md
@@ -89,6 +89,8 @@ if { g somefile.txt } else {
 
 ## Detail
 
+### Pipelines and Output
+
 The conditional block can contain entire pipelines - even multiple lines of code
 let alone a single pipeline - as well as solitary commands as demonstrated in
 the examples above. However the conditional block does not output STDOUT nor
@@ -99,6 +101,23 @@ If you require output from the conditional blocks STDOUT then you will need to
 use either a Murex named pipe to redirect the output, or test or debug flags
 (depending on your use case) if you only need to occasionally inspect the
 conditionals output.
+
+### Exit Numbers
+
+When evaluating a command or code block, `if` will treat an exit number less
+than 0 as true, and one greater than 0 as false. When the exit number is 0, `if`
+will examine the stdout of the command or code block. If there is no output, or
+the output is one of the following strings, `if` will evaluate the command or
+code block as false. Otherwise, it will be considered true.
+
+* `0`
+* `disabled`
+* `fail`
+* `failed`
+* `false`
+* `no`
+* `null`
+* `off`
 
 ## Synonyms
 


### PR DESCRIPTION
Was scratching my head over why
```
if { some_command -> grep -q "foo" } then { do_something } else { do_something_else }
```
wasn't behaving as I expected until I read the source code to figure it out. Hopefully I can save someone else a perusal of the source code :grin: 