### PR TITLE
Add '-quiet' flag

### DIFF
--- a/config/profile/module.go
+++ b/config/profile/module.go
@@ -12,6 +12,7 @@ import (
 	"github.com/lmorg/murex/builtins/pipes/term"
 	"github.com/lmorg/murex/lang"
 	"github.com/lmorg/murex/lang/ref"
+	"github.com/lmorg/murex/lang/types"
 	"github.com/lmorg/murex/shell/autocomplete"
 	"github.com/lmorg/murex/utils"
 	"github.com/lmorg/murex/utils/ansi"
@@ -128,7 +129,11 @@ func (m *Module) execute() error {
 
 	block := []rune(string(b))
 
-	os.Stderr.WriteString(fmt.Sprintf("Loading module `%s/%s`%s", m.Package, m.Name, utils.NewLineString))
+	quiet, _ := lang.ShellProcess.Config.Get("shell", "quiet", types.Boolean)
+
+	if !quiet.(bool) {
+		os.Stderr.WriteString(fmt.Sprintf("Loading module `%s/%s`%s", m.Package, m.Name, utils.NewLineString))
+	}
 
 	fork := lang.ShellProcess.Fork(lang.F_NEW_MODULE | lang.F_FUNCTION | lang.F_NO_STDIN)
 	// lets redirect all output to STDERR just in case this thing gets piped

--- a/config/profile/profile.go
+++ b/config/profile/profile.go
@@ -9,6 +9,7 @@ import (
 	"github.com/lmorg/murex/builtins/pipes/term"
 	"github.com/lmorg/murex/lang"
 	"github.com/lmorg/murex/lang/ref"
+	"github.com/lmorg/murex/lang/types"
 	"github.com/lmorg/murex/shell/autocomplete"
 	"github.com/lmorg/murex/utils"
 	"github.com/lmorg/murex/utils/ansi"
@@ -106,7 +107,11 @@ func profile(name, path string) error {
 
 	block := []rune(string(b))
 
-	os.Stderr.WriteString("Loading profile `" + name + "`" + utils.NewLineString)
+	quiet, _ := lang.ShellProcess.Config.Get("shell", "quiet", types.Boolean)
+
+	if !quiet.(bool) {
+		os.Stderr.WriteString("Loading profile `" + name + "`" + utils.NewLineString)
+	}
 
 	// lets redirect all output to STDERR just in case this thing gets piped for any strange reason
 	fork := lang.ShellProcess.Fork(lang.F_NEW_MODULE | lang.F_NEW_TESTS | lang.F_NO_STDIN)

--- a/flags.go
+++ b/flags.go
@@ -24,6 +24,7 @@ var (
 	fVersion2    bool
 	fSh          bool
 	fRunTests    bool
+	fQuiet       bool
 )
 
 func readFlags() {
@@ -41,6 +42,7 @@ func readFlags() {
 	flag.BoolVar(&fRunTests, "run-tests", false, "Run all tests and exit")
 	flag.BoolVar(&fEcho, "echo", false, "Echo on")
 	flag.BoolVar(&fSh, "murex", false, "")
+	flag.BoolVar(&fQuiet, "quiet", false, "Suppress messages about loading profiles and modules.")
 
 	flag.BoolVar(&lang.FlagTry, "try", false, "Enable a global `try` block")
 	flag.BoolVar(&lang.FlagTryPipe, "trypipe", false, "Enable a global `trypipe` block")
@@ -64,6 +66,12 @@ func readFlags() {
 	config.InitConf.Define("proc", "echo", config.Properties{
 		Description: "Echo shell functions",
 		Default:     fEcho,
+		DataType:    types.Boolean,
+	})
+
+	config.InitConf.Define("shell", "quiet", config.Properties{
+		Description: "Prevent messages about loading profiles and modules from being printed at startup",
+		Default:     fQuiet,
 		DataType:    types.Boolean,
 	})
 


### PR DESCRIPTION
Adds a `-quiet` flag to prevent printing of `Loading profile`/`Loading module` messages when the shell starts up, per #797 