### PR TITLE
Close stdin after write in unmarshal

### DIFF
--- a/lang/define_unmarshal.go
+++ b/lang/define_unmarshal.go
@@ -47,8 +47,10 @@ func UnmarshalDataBuffered(parent *Process, b []byte, dataType string) (any, err
 	fork := parent.Fork(F_BACKGROUND | F_CREATE_STDIN | F_NO_STDOUT | F_NO_STDERR)
 	defer fork.Kill()
 
-	_, err := fork.Stdin.Write(b)
+	fork.Stdin.Open()
 	defer fork.Stdin.Close()
+
+	_, err := fork.Stdin.Write(b)
 	if err != nil {
 		return nil, fmt.Errorf("cannot write value to unmarshaller's buffer: %s", err.Error())
 	}

--- a/lang/define_unmarshal.go
+++ b/lang/define_unmarshal.go
@@ -48,12 +48,12 @@ func UnmarshalDataBuffered(parent *Process, b []byte, dataType string) (any, err
 	defer fork.Kill()
 
 	fork.Stdin.Open()
-	defer fork.Stdin.Close()
-
 	_, err := fork.Stdin.Write(b)
+	fork.Stdin.Close()
 	if err != nil {
 		return nil, fmt.Errorf("cannot write value to unmarshaller's buffer: %s", err.Error())
 	}
+
 	v, err := UnmarshalData(fork.Process, dataType)
 	if err != nil {
 		return nil, fmt.Errorf("cannot unmarshal buffer: %s", err.Error())

--- a/lang/define_unmarshal_test.go
+++ b/lang/define_unmarshal_test.go
@@ -5,10 +5,32 @@ import (
 	"testing"
 
 	_ "github.com/lmorg/murex/builtins"
+	"github.com/lmorg/murex/debug"
 	"github.com/lmorg/murex/lang"
 	"github.com/lmorg/murex/lang/types"
 	"github.com/lmorg/murex/test/count"
 )
+
+func TestUnmarshalDataBufferedDebug(t *testing.T) {
+	count.Tests(t, 1)
+
+	input := `["a","b","c"]`
+
+	lang.InitEnv()
+
+	debug.Enabled = true
+	defer func() { debug.Enabled = false }()
+
+	v, err := lang.UnmarshalDataBuffered(lang.ShellProcess, []byte(input), types.Json)
+	if err != nil {
+		t.Error(err)
+		return
+	}
+
+	if fmt.Sprintf("%v", v) != "[a b c]" {
+		t.Errorf("unexpected output: %v", v)
+	}
+}
 
 func TestUnmarshalArrayJsonString(t *testing.T) {
 	count.Tests(t, 1)


### PR DESCRIPTION
Fixes #987

The issue was that stdin was getting closed before the write completed. Moving the close call after the write ensures the data actually gets flushed to the unmarshaller. This was preventing su root and similar commands from working properly.