### PR TITLE
Fix panic in comparison operators with non-comparable types

### DIFF
--- a/lang/expressions/exp06.go
+++ b/lang/expressions/exp06.go
@@ -31,7 +31,17 @@ func expGtLt(tree *ParserT, compareFloat ltGtFT, compareString ltGtST) error {
 		value = compareFloat(convertNumber(lv), convertNumber(rv))
 
 	case string:
-		value = compareString(lv.(string), rv.(string))
+		rvStr, ok := rv.(string)
+		if !ok {
+			v, convErr := types.ConvertGoType(rv, types.String)
+			if convErr != nil {
+				return raiseError(tree.expression, tree.currentSymbol(), 0, fmt.Sprintf(
+					"cannot %s with %s types", tree.currentSymbol().key, left.Primitive,
+				))
+			}
+			rvStr = v.(string)
+		}
+		value = compareString(lv.(string), rvStr)
 
 	default:
 		return raiseError(tree.expression, tree.currentSymbol(), 0, fmt.Sprintf(

--- a/lang/expressions/exp06_test.go
+++ b/lang/expressions/exp06_test.go
@@ -181,3 +181,62 @@ func TestExpLessThanOrEqual(t *testing.T) {
 
 	testExpression(t, tests, true)
 }
+
+// TestExpCompareNonComparableStrict is a regression test for
+// https://github.com/lmorg/murex/issues/982
+// Comparing a non-comparable type (e.g. array) with a number
+// should return an error, not panic.
+func TestExpCompareNonComparableStrict(t *testing.T) {
+	tests := []expressionTestT{
+		{
+			Expression: `%[1,2,3] < 2`,
+			Error:      true,
+		},
+		{
+			Expression: `2 < %[1,2,3]`,
+			Error:      true,
+		},
+		{
+			Expression: `%[1,2,3] > 2`,
+			Error:      true,
+		},
+		{
+			Expression: `%[1,2,3] <= 2`,
+			Error:      true,
+		},
+		{
+			Expression: `%[1,2,3] >= 2`,
+			Error:      true,
+		},
+	}
+
+	testExpression(t, tests, true)
+}
+
+// TestExpCompareNonComparableNonStrict is a regression test for
+// https://github.com/lmorg/murex/issues/982
+// In non-strict mode, comparing a non-comparable type with a number
+// previously panicked with "interface conversion: interface {} is float64,
+// not string". After the fix, this should not panic.
+func TestExpCompareNonComparableNonStrict(t *testing.T) {
+	tests := []expressionTestT{
+		{
+			Expression: `%[1,2,3] < 2`,
+			Expected:   false,
+		},
+		{
+			Expression: `2 > %[1,2,3]`,
+			Expected:   true,
+		},
+		{
+			Expression: `%[1,2,3] > 2`,
+			Expected:   true,
+		},
+		{
+			Expression: `2 < %[1,2,3]`,
+			Expected:   false,
+		},
+	}
+
+	testExpression(t, tests, false)
+}

--- a/lang/expressions/exp06_test.go
+++ b/lang/expressions/exp06_test.go
@@ -236,6 +236,22 @@ func TestExpCompareNonComparableNonStrict(t *testing.T) {
 			Expression: `2 < %[1,2,3]`,
 			Expected:   false,
 		},
+		{
+			Expression: `%[1,2,3] <= 2`,
+			Expected:   false,
+		},
+		{
+			Expression: `2 >= %[1,2,3]`,
+			Expected:   true,
+		},
+		{
+			Expression: `%[1,2,3] >= 2`,
+			Expected:   true,
+		},
+		{
+			Expression: `2 <= %[1,2,3]`,
+			Expected:   false,
+		},
 	}
 
 	testExpression(t, tests, false)


### PR DESCRIPTION
Fixes #982

**Failing scenario:** In non-strict mode, `@PWD < 2` (or any expression comparing a non-comparable type like an array with a number via `<`, `>`, `<=`, `>=`) panics:

```
panic: interface conversion: interface {} is float64, not string
```

**Root cause:** `compareTypes()` returns mismatched Go types when one operand is non-comparable — the non-comparable side gets JSON-marshaled to a string while the comparable side retains its original Go type (e.g. `float64`). In `expGtLt`, the string case branch does `rv.(string)` without checking the actual type, causing the panic.

**Fix:** Add a safe type assertion in the string comparison branch. When `rv` is not already a string, convert it via `types.ConvertGoType(rv, types.String)` before comparing.

**Before:** `@PWD < 2` → panic
**After:** `@PWD < 2` → returns a boolean (string comparison)

**Validation:**
- `go test ./lang/expressions/` — all existing tests pass
- `go vet ./lang/expressions/` — clean
- Added regression tests for both strict and non-strict modes
- Verified the new test panics without the fix and passes with it