### PR TITLE
Update 'which' not to search CWD when cmd doesn't contain a separator

### DIFF
--- a/utils/which/which.go
+++ b/utils/which/which.go
@@ -2,10 +2,9 @@ package which
 
 import (
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
-
-	"github.com/lmorg/murex/utils/consts"
 )
 
 // Which works similarly to the UNIX command with the same name.
@@ -21,18 +20,14 @@ func Which(cmd string) string {
 			return cmd
 		}
 		return ""
-	} else {
-		// cmd is not explicitly a path, just search $PATH, don't attempt to reoslve absolute path
-		for _, path := range SplitPath(os.Getenv("PATH")) {
-			fullPath := path + consts.PathSlash + cmd
-			fi, err := os.Stat(fullPath)
-			if err == nil && fi.Mode().IsRegular() {
-				return fullPath
-			}
-		}
+	}
 
+	// cmd is not explicitly a path, just search $PATH
+	path, err := exec.LookPath(cmd)
+	if err != nil {
 		return ""
 	}
+	return path
 }
 
 // WhichIgnoreFail will always return a best guess of the executable

--- a/utils/which/which.go
+++ b/utils/which/which.go
@@ -2,29 +2,37 @@ package which
 
 import (
 	"os"
+	"path/filepath"
+	"strings"
 
 	"github.com/lmorg/murex/utils/consts"
 )
 
 // Which works similarly to the UNIX command with the same name.
-// If the executable is now found in $PATH then a zero length string is returned.
+// If the executable is not found in $PATH then a zero length string is returned.
 func Which(cmd string) string {
-	_, err := os.Stat(cmd)
-	if !os.IsNotExist(err) {
-		return cmd
-	}
-
-	envPath := os.Getenv("PATH")
-
-	for _, path := range SplitPath(envPath) {
-		filepath := path + consts.PathSlash + cmd
-		_, err := os.Stat(filepath)
-		if !os.IsNotExist(err) {
-			return filepath
+	if strings.ContainsRune(cmd, '/') || strings.ContainsRune(cmd, filepath.Separator) {
+		// cmd is explicitly a path, resolve and return the absolute path if possible
+		fi, err := os.Stat(cmd)
+		if err == nil && fi.Mode().IsRegular() {
+			if abs, err := filepath.Abs(cmd); err == nil {
+				return abs
+			}
+			return cmd
 		}
-	}
+		return ""
+	} else {
+		// cmd is not explicitly a path, just search $PATH, don't attempt to reoslve absolute path
+		for _, path := range SplitPath(os.Getenv("PATH")) {
+			fullPath := path + consts.PathSlash + cmd
+			fi, err := os.Stat(fullPath)
+			if err == nil && fi.Mode().IsRegular() {
+				return fullPath
+			}
+		}
 
-	return ""
+		return ""
+	}
 }
 
 // WhichIgnoreFail will always return a best guess of the executable

--- a/utils/which/which_test.go
+++ b/utils/which/which_test.go
@@ -23,3 +23,29 @@ func TestWhich(t *testing.T) {
 		t.Log("$PATH: " + os.Getenv("PATH"))
 	}
 }
+
+func TestWhichDirInCwd(t *testing.T) {
+	count.Tests(t, 1)
+
+	tmp := t.TempDir()
+	// make a dir with the same name as a real executable
+	if err := os.Mkdir(tmp+"/go", 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	old, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Chdir(old)
+
+	if err := os.Chdir(tmp); err != nil {
+		t.Fatal(err)
+	}
+
+	result := Which("go")
+
+	if result == "go" || result == "" {
+		t.Errorf("Which(\"go\") returned %q; expected the resultolved $PATH path", result)
+	}
+}


### PR DESCRIPTION
Relates to #994

Updated `which` to only return files not in `$PATH` when they're regular files and the query contains the path separator. `which` now also attempts to return absolute paths.

When `which` queries don't contain the path separator, only `$PATH` is scanned.

This is a somewhat opinionated change, made before there's been time for meaningful discussion in the issue, so this PR is really just a draft for discussion.

Also, I considered using `exec.LookPath` rather than rolling my own loop, but noticed it isn't used anywhere in the codebase. Not sure if there's a subtlety I'm missing as to why not, so I got spooked and wrote a loop instead.

I've been able to test my specific test cases but not the full test suite due to the preexisting state of develop.